### PR TITLE
added support to search fixed size list by FK and order to sort in plain entity

### DIFF
--- a/src/main/java/com/appmetr/hercules/dao/AbstractDAO.java
+++ b/src/main/java/com/appmetr/hercules/dao/AbstractDAO.java
@@ -88,12 +88,12 @@ public abstract class AbstractDAO<E, K> {
         return getHercules().getEntityManager().getByFK(entityClass, foreignKey, dataOperationsProfile);
     }
 
-    public List<E> getFixedSizeListByFK(ForeignKey foreignKey, Integer count, boolean reverse) {
-        return getHercules().getEntityManager().getFixedSizeListByFK(entityClass, foreignKey, count, reverse, null);
+    public List<E> getByFK(ForeignKey foreignKey, boolean reverse, Integer count) {
+        return getHercules().getEntityManager().getByFK(entityClass, foreignKey, reverse, count, null);
     }
 
-    public List<E> getFixedSizeListByFK(ForeignKey foreignKey, Integer count, boolean reverse, DataOperationsProfile dataOperationsProfile) {
-        return getHercules().getEntityManager().getFixedSizeListByFK(entityClass, foreignKey, count, reverse, dataOperationsProfile);
+    public List<E> getByFK(ForeignKey foreignKey, boolean reverse, Integer count, DataOperationsProfile dataOperationsProfile) {
+        return getHercules().getEntityManager().getByFK(entityClass, foreignKey, reverse, count, dataOperationsProfile);
     }
 
     public List<E> getByFK(ForeignKey foreignKey, Set<K> skipKeys, DataOperationsProfile dataOperationsProfile) {

--- a/src/main/java/com/appmetr/hercules/dao/AbstractDAO.java
+++ b/src/main/java/com/appmetr/hercules/dao/AbstractDAO.java
@@ -88,6 +88,14 @@ public abstract class AbstractDAO<E, K> {
         return getHercules().getEntityManager().getByFK(entityClass, foreignKey, dataOperationsProfile);
     }
 
+    public List<E> getFixedSizeListByFK(ForeignKey foreignKey, Integer count, boolean reverse) {
+        return getHercules().getEntityManager().getFixedSizeListByFK(entityClass, foreignKey, count, reverse, null);
+    }
+
+    public List<E> getFixedSizeListByFK(ForeignKey foreignKey, Integer count, boolean reverse, DataOperationsProfile dataOperationsProfile) {
+        return getHercules().getEntityManager().getFixedSizeListByFK(entityClass, foreignKey, count, reverse, dataOperationsProfile);
+    }
+
     public List<E> getByFK(ForeignKey foreignKey, Set<K> skipKeys, DataOperationsProfile dataOperationsProfile) {
         return getHercules().getEntityManager().getByFK(entityClass, foreignKey, skipKeys, dataOperationsProfile);
     }

--- a/src/main/java/com/appmetr/hercules/manager/EntityManager.java
+++ b/src/main/java/com/appmetr/hercules/manager/EntityManager.java
@@ -170,10 +170,18 @@ public class EntityManager {
         return getByFK(clazz, foreignKey, null, skipKeys, dataOperationsProfile);
     }
 
+    private <E, K> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, Integer count, Set<K> skipKeys, DataOperationsProfile dataOperationsProfile) {
+        return getByFK(clazz, foreignKey, count, false, skipKeys, dataOperationsProfile);
+    }
+
     public <E> E getSingleByFK(Class<E> clazz, ForeignKey foreignKey, DataOperationsProfile dataOperationsProfile) {
         List<E> entites = getByFK(clazz, foreignKey, 1, null, dataOperationsProfile);
 
         return entites.size() > 0 ? entites.get(0) : null;
+    }
+
+    public <E> List<E> getFixedSizeListByFK(Class<E> clazz, ForeignKey foreignKey, Integer count, boolean reverse, DataOperationsProfile dataOperationsProfile) {
+        return getByFK(clazz, foreignKey, count, reverse, null, dataOperationsProfile);
     }
 
     public <E, U> List<E> getByCollectionIndex(Class<E> clazz, String indexedFieldame, U indexValue, DataOperationsProfile dataOperationsProfile) {
@@ -466,7 +474,7 @@ public class EntityManager {
         }
     }
 
-    private <E, K> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, Integer count, Set<K> skipKeys,
+    private <E, K> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, Integer count, boolean reverse, Set<K> skipKeys,
                                    DataOperationsProfile dataOperationsProfile) {
         StopWatch monitor = monitoring.start(HerculesMonitoringGroup.HERCULES_EM, "Get list by FK " + clazz.getSimpleName());
 
@@ -476,7 +484,7 @@ public class EntityManager {
 
             HerculesQueryResult<K> queryResult = dataDriver.getSlice(hercules.getKeyspace(), foreignKeyMetadata.getColumnFamily(), dataOperationsProfile,
                     new ByteArrayRowSerializer<Object, K>(getForeignKeySerializer(metadata.getIndexMetadata(foreignKey.getClass())), this.<K>getPrimaryKeySerializer(metadata)),
-                    foreignKey, new SliceDataSpecificator<K>(null, null, false, count));
+                    foreignKey, new SliceDataSpecificator<K>(null, null, reverse, count));
 
             if (queryResult.hasResult()) {
                 countEntities(dataOperationsProfile, queryResult.getEntries());

--- a/src/main/java/com/appmetr/hercules/manager/EntityManager.java
+++ b/src/main/java/com/appmetr/hercules/manager/EntityManager.java
@@ -163,25 +163,23 @@ public class EntityManager {
     }
 
     public <E> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, DataOperationsProfile dataOperationsProfile) {
-        return getByFK(clazz, foreignKey, null, null, dataOperationsProfile);
+        return getByFK(clazz, foreignKey, false, null, null, dataOperationsProfile);
     }
 
     public <E, K> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, Set<K> skipKeys, DataOperationsProfile dataOperationsProfile) {
-        return getByFK(clazz, foreignKey, null, skipKeys, dataOperationsProfile);
+        return getByFK(clazz, foreignKey, false, null, skipKeys, dataOperationsProfile);
     }
 
-    private <E, K> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, Integer count, Set<K> skipKeys, DataOperationsProfile dataOperationsProfile) {
-        return getByFK(clazz, foreignKey, count, false, skipKeys, dataOperationsProfile);
+
+    public <E> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, boolean reverse, Integer count, DataOperationsProfile dataOperationsProfile) {
+        return getByFK(clazz, foreignKey, reverse, count, null, dataOperationsProfile);
     }
+
 
     public <E> E getSingleByFK(Class<E> clazz, ForeignKey foreignKey, DataOperationsProfile dataOperationsProfile) {
-        List<E> entites = getByFK(clazz, foreignKey, 1, null, dataOperationsProfile);
+        List<E> entites = getByFK(clazz, foreignKey, false, 1, null, dataOperationsProfile);
 
         return entites.size() > 0 ? entites.get(0) : null;
-    }
-
-    public <E> List<E> getFixedSizeListByFK(Class<E> clazz, ForeignKey foreignKey, Integer count, boolean reverse, DataOperationsProfile dataOperationsProfile) {
-        return getByFK(clazz, foreignKey, count, reverse, null, dataOperationsProfile);
     }
 
     public <E, U> List<E> getByCollectionIndex(Class<E> clazz, String indexedFieldame, U indexValue, DataOperationsProfile dataOperationsProfile) {
@@ -474,7 +472,7 @@ public class EntityManager {
         }
     }
 
-    private <E, K> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, Integer count, boolean reverse, Set<K> skipKeys,
+    private <E, K> List<E> getByFK(Class<E> clazz, ForeignKey foreignKey, boolean reverse, Integer count, Set<K> skipKeys,
                                    DataOperationsProfile dataOperationsProfile) {
         StopWatch monitor = monitoring.start(HerculesMonitoringGroup.HERCULES_EM, "Get list by FK " + clazz.getSimpleName());
 


### PR DESCRIPTION
For some cases i need list of n first(last)  objects.
I noticed that realization of method getByFK provide this functionality, but method is private and its public overloads not allow use this functionality