### PR TITLE
Replace asList with singletonList in WideEntityManager

### DIFF
--- a/src/main/java/com/appmetr/hercules/manager/WideEntityManager.java
+++ b/src/main/java/com/appmetr/hercules/manager/WideEntityManager.java
@@ -1,5 +1,7 @@
 package com.appmetr.hercules.manager;
 
+import static java.util.Collections.singletonList;
+
 import com.appmetr.hercules.Hercules;
 import com.appmetr.hercules.HerculesMonitoringGroup;
 import com.appmetr.hercules.annotations.TopKey;
@@ -247,7 +249,7 @@ public class WideEntityManager {
     }
 
     public <E, R> void delete(Class<?> clazz, R rowKey, E entity, DataOperationsProfile dataOperationsProfile) {
-        deleteByKeys(clazz, rowKey, Arrays.asList(getTopKey(entity, getMetadata(entity.getClass()))), dataOperationsProfile);
+        deleteByKeys(clazz, rowKey, singletonList(getTopKey(entity, getMetadata(entity.getClass()))), dataOperationsProfile);
     }
 
     public <E, R, T> void delete(Class<?> clazz, R rowKey, Iterable<E> entities, DataOperationsProfile dataOperationsProfile) {
@@ -261,7 +263,7 @@ public class WideEntityManager {
     }
 
     public <R, T> void deleteByKey(Class<?> clazz, R rowKey, T topKey, DataOperationsProfile dataOperationsProfile) {
-        deleteByKeys(clazz, rowKey, Arrays.asList(topKey), dataOperationsProfile);
+        deleteByKeys(clazz, rowKey, singletonList(topKey), dataOperationsProfile);
     }
 
     public <R, T> void deleteByKeys(Class<?> clazz, R rowKey, Iterable<T> topKeys, DataOperationsProfile dataOperationsProfile) {


### PR DESCRIPTION
Использование Arrays.asList приводит к ClassCastException, например
`
java.lang.ClassCastException: class com.pixonic.battlemech.model.Top cannot be cast to class [Ljava.lang.Object; (com.pixonic.battlemech.model.Top is in unnamed module of loader 'app'; [Ljava.lang.Object; is in module java.base of loader 'bootstrap')
	at com.appmetr.hercules.manager.WideEntityManager.delete(WideEntityManager.java:250) ~[hercules-0.5.5.jar:na]
	at com.appmetr.hercules.dao.AbstractWideDAO.delete(AbstractWideDAO.java:164) ~[hercules-0.5.5.jar:na]
	at com.appmetr.hercules.dao.AbstractWideDAO.delete(AbstractWideDAO.java:160) ~[hercules-0.5.5.jar:na]
`
